### PR TITLE
Decouple User from CartItem creation in addToCart()

### DIFF
--- a/src/Bookazon.java
+++ b/src/Bookazon.java
@@ -59,8 +59,8 @@ public class Bookazon {
         bookazon.addUser(new User("Bob", Subscription.GOLD, new Cart()));
 
         // add books to cart
-        bookazon.users.get(0).addToCart(bookazon.mediaList.get(0), 1);
-        bookazon.users.get(0).addToCart(bookazon.mediaList.get(1), 2);
+        bookazon.users.get(0).addToCart(new CartItem(bookazon.mediaList.get(0).getTitle(), bookazon.mediaList.get(0).getPrice(), 1));
+        bookazon.users.get(0).addToCart(new CartItem(bookazon.mediaList.get(1).getTitle(), bookazon.mediaList.get(1).getPrice(), 2));
 
         // view cart
         bookazon.users.get(0).viewCart();

--- a/src/User.java
+++ b/src/User.java
@@ -40,8 +40,8 @@ public class User {
         this.billingAddress = billingAddress;
     }
 
-    public void addToCart(Media media, int quantity) {
-        cart.addItem(new CartItem(media.getTitle(), media.getPrice(), quantity));
+    public void addToCart(CartItem cartItem) {
+        cart.addItem(cartItem);
     }
 
     public void removeFromCart(Media media) {


### PR DESCRIPTION
- Problem: `User.java`'s `addToCart()` method was tightly coupled to `CartItem` creation.
- Solution: Refactored `addToCart()` to accept a `CartItem` as a parameter.
- Tests: Created `CartItem` in `Bookazon.java` and works as intended.